### PR TITLE
grid_download download error handling

### DIFF
--- a/src/cbers4asat/tools/grid.py
+++ b/src/cbers4asat/tools/grid.py
@@ -44,6 +44,8 @@ def grid_download(
                     for chunk in req.iter_content(chunk_size=1024):
                         if chunk:
                             f.write(chunk)
+            else:
+                raise ValueError("Download unavailable")
         else:
             raise ValueError("Sensors available: mux and wfi")
     else:


### PR DESCRIPTION
Em complemento à issue #15 que abri.

Incluí tratamento caso o donwload do grid esteja indisponível, conforme documentado na issue. O tratamento consiste no "else" do bloco de código copiado abaixo:

```python

  if req.status_code == 200:
      with open(join(outdir, filename), "wb") as f:
          for chunk in req.iter_content(chunk_size=1024):
              if chunk:
                  f.write(chunk)
  else:
      raise ValueError("Download unavailable")
```

[Código original: src/cbers4asat/tools/grid.py](https://github.com/gabriel-russo/cbers4asat/blob/c087b8613dcaf357ccf79a468298a211e7725cb4/src/cbers4asat/tools/grid.py#L42)