### PR TITLE
Fix Download dos produtos retornados do método query

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cbers4asat"
-version = "0.8.1"
+version = "0.8.2"
 description = "Biblioteca Python para realizar a busca e processamento de imagens dos satélites CBERS-04A e AMAZONIA-1"
 authors = [
     { name = "Gabriel Russo", email = "gabrielrusso@protonmail.com" }]


### PR DESCRIPTION
Após verificações, notou-se que a busca na API do STAC não retornava os metadados completos, faltando os links para os assets (.tif).