### PR TITLE
Inclui a possibilidade de obter também o .xml das imagens.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 license = { file = "LICENSE" }
 keywords = ["cbers", "cbers4a", "cbers-04a", "amazonia-1", "remote sensing", "geoprocessing"]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9,<4"
 classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/cbers4asat/cbers4asat.py
+++ b/src/cbers4asat/cbers4asat.py
@@ -134,6 +134,7 @@ class Cbers4aAPI:
         threads: int = cpu_count(),
         outdir: str = getcwd(),
         with_folder: bool = False,
+        with_metadata: bool = False,
     ):
         try:
             products = ItemCollection(**products)
@@ -154,6 +155,11 @@ class Cbers4aAPI:
                 tasks.append(
                     (Download().download, product.band_url(band), self.email, outdir)
                 )
+                if with_metadata:
+                    url_xml = product.band_url(band).replace('.tif', '.xml')
+                    tasks.append(
+                        (Download().download, url_xml, self.email, outdir)
+                    )
 
         with ThreadPoolExecutor(max_workers=threads) as t_pool:
             for task in tasks:
@@ -168,6 +174,7 @@ class Cbers4aAPI:
         threads: int = cpu_count(),
         outdir: str = getcwd(),
         with_folder: bool = False,
+        with_metadata: bool = False,
     ):
         features = list()
         for index, row in products.iterrows():
@@ -185,6 +192,12 @@ class Cbers4aAPI:
                 tasks.append(
                     (Download().download, product.band_url(band), self.email, outdir)
                 )
+                if with_metadata:
+                    url_xml = product.band_url(band).replace('.tif', '.xml')
+                    tasks.append(
+                        (Download().download, url_xml, self.email, outdir)
+                    )
+
 
         with ThreadPoolExecutor(max_workers=threads) as t_pool:
             for task in tasks:
@@ -199,6 +212,7 @@ class Cbers4aAPI:
         threads: int = cpu_count(),
         outdir: str = getcwd(),
         with_folder: bool = False,
+        with_metadata: bool = False,
     ):
         """
         Download bands from all given scenes
@@ -225,11 +239,11 @@ class Cbers4aAPI:
         if isinstance(products, dict):
             if not products:  # Check if dictionary is empty
                 raise Exception("No product to download.")
-            return self.__download(products, bands, threads, outdir, with_folder)
+            return self.__download(products, bands, threads, outdir, with_folder, with_metadata)
         elif isinstance(products, GeoDataFrame):
             if products.empty:  # Check if data frame is empty
                 raise Exception("No product to download.")
-            return self.__download_gdf(products, bands, threads, outdir, with_folder)
+            return self.__download_gdf(products, bands, threads, outdir, with_folder, with_metadata)
         else:
             raise Exception("Bad Arguments.")
 


### PR DESCRIPTION
Estudando questões relacionadas à correção atmosférica e conversão de DN para radiância, vi que existem parâmetros que estão nos metadados das imagens do INPE --- obtidos no arquivo *.xml* do https://www.dgi.inpe.br/catalogo/explore ---  que podem ser bastante úteis, tais como:

```xml
<absoluteCalibrationCoefficient>
  <band name="0">0.184471</band>  <!-- PAN -->
  <band name="1">0.29107</band>   <!-- BLUE -->
  <band name="2">0.297832</band>  <!-- GREEN -->
  <band name="3">0.232504</band>  <!-- RED -->
  <band name="4">0.178993</band>  <!-- NIR -->
</absoluteCalibrationCoefficient>
```


Tomei a liberdade de fazer umas breve alterações no código para permitir que o `cbers4asat` também faça o *download* dos metadados.
Entendo que, idealmente, a *url* que aponta para o *.xml* deveria estar no resultado do STAC do INPE, sendo mais fácil mapear a *url* e, por consequência, fazer o *download*. Contudo, como não é o caso, optei por uma solução que não é a ideal.
```python
product.band_url(band).replace('.tif', '.xml')
```

Ah, alterei também as dependências pois deu conflitos com alguns pacotes `requires-python = ">=3.9,<4"`....